### PR TITLE
favour extension over mimetype

### DIFF
--- a/tests/test_csv_helper.py
+++ b/tests/test_csv_helper.py
@@ -12,44 +12,60 @@ def get_fixture(filename, content_type):
 
 class CsvHelperTests(TestCase):
     def test_valid_idox_eros(self):
-        report = get_csv_report(get_fixture("ems-idox-eros.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ems-idox-eros.csv", "text/csv"), "ems-idox-eros.csv"
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
         self.assertEqual("Idox Eros (Halarose)", report["ems"])
 
     def test_valid_xpress_dc(self):
-        report = get_csv_report(get_fixture("ems-xpress-dc.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ems-xpress-dc.csv", "text/csv"), "ems-xpress-dc.csv"
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
         self.assertEqual("Xpress DC", report["ems"])
 
     def test_valid_weblookup(self):
-        report = get_csv_report(get_fixture("ems-xpress-weblookup.CSV", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ems-xpress-weblookup.CSV", "text/csv"),
+            "ems-xpress-weblookup.CSV",
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
         self.assertEqual("Xpress WebLookup", report["ems"])
 
     def test_dcounts_stations(self):
-        report = get_csv_report(get_fixture("ems-dcounts-stations.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ems-dcounts-stations.csv", "text/csv"),
+            "ems-dcounts-stations.csv",
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(20, report["csv_rows"])
         self.assertEqual("Democracy Counts", report["ems"])
 
     def test_dcounts_districts(self):
-        report = get_csv_report(get_fixture("ems-dcounts-districts.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ems-dcounts-districts.csv", "text/csv"),
+            "ems-dcounts-districts.csv",
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(20, report["csv_rows"])
         self.assertEqual("Democracy Counts", report["ems"])
 
     def test_valid_other(self):
-        report = get_csv_report(get_fixture("ems-other.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ems-other.csv", "text/csv"), "ems-other.csv"
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
         self.assertEqual("unknown", report["ems"])
 
     def test_valid_windows1252(self):
         report = get_csv_report(
-            get_fixture("encoding-windows1252.tsv", "text/tab-separated-values")
+            get_fixture("encoding-windows1252.tsv", "text/tab-separated-values"),
+            "encoding-windows1252.tsv",
         )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
@@ -57,29 +73,40 @@ class CsvHelperTests(TestCase):
 
     def test_edgecase_csv_with_tsv_ext(self):
         report = get_csv_report(
-            get_fixture("ext-csv-with-tsv-ext.tsv", "text/tab-separated-values")
+            get_fixture("ext-csv-with-tsv-ext.tsv", "text/tab-separated-values"),
+            "ext-csv-with-tsv-ext.tsv",
         )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
 
     def test_edgecase_tsv_with_csv_ext(self):
-        report = get_csv_report(get_fixture("ext-tsv-with-csv-ext.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("ext-tsv-with-csv-ext.csv", "text/csv"),
+            "ext-tsv-with-csv-ext.csv",
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(10, report["csv_rows"])
 
     def test_edgecase_nearly_empty_file(self):
-        report = get_csv_report(get_fixture("small-files-nearly_empty.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("small-files-nearly_empty.csv", "text/csv"),
+            "small-files-nearly_empty.csv",
+        )
         self.assertTrue(report["csv_valid"])
         self.assertEqual(1, report["csv_rows"])
         self.assertEqual("unknown", report["ems"])
 
     def test_invalid_empty_file(self):
-        report = get_csv_report(get_fixture("small-files-empty.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("small-files-empty.csv", "text/csv"), "small-files-empty.csv"
+        )
         self.assertFalse(report["csv_valid"])
         self.assertEqual("File is empty", report["errors"][0])
 
     def test_invalid_empty_file2(self):
-        report = get_csv_report(get_fixture("small-files-empty2.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("small-files-empty2.csv", "text/csv"), "small-files-empty2.csv"
+        )
         # this file is just a single line break
         self.assertFalse(report["csv_valid"])
         self.assertEqual(
@@ -88,7 +115,9 @@ class CsvHelperTests(TestCase):
         )
 
     def test_invalid_incomplete_file(self):
-        report = get_csv_report(get_fixture("incomplete-file.CSV", "text/csv"))
+        report = get_csv_report(
+            get_fixture("incomplete-file.CSV", "text/csv"), "incomplete-file.CSV"
+        )
         self.assertFalse(report["csv_valid"])
         self.assertEqual(
             "Incomplete file: Expected 38 columns on row 10 found 7",
@@ -96,6 +125,8 @@ class CsvHelperTests(TestCase):
         )
 
     def test_invalid_not_a_csv(self):
-        report = get_csv_report(get_fixture("not-a-csv.csv", "text/csv"))
+        report = get_csv_report(
+            get_fixture("not-a-csv.csv", "text/csv"), "not-a-csv.csv"
+        )
         self.assertFalse(report["csv_valid"])
         self.assertEqual("Failed to parse body", report["errors"][0])

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -308,7 +308,7 @@ class HandlerTests(TestCase):
             ses_backend.sent_messages[0].subject,
         )
 
-    def test_valid_excel_imietype(self):
+    def test_valid_excel_mimetype(self):
         self.load_fixture("ems-idox-eros.csv", mimetype="application/vnd.ms-excel")
 
         main(trigger_payload, None)

--- a/trigger/handler.py
+++ b/trigger/handler.py
@@ -28,14 +28,6 @@ def register_env():
     }
 
 
-def fix_mime_type(key, obj):
-    if obj["ContentType"] not in ("text/csv", "text/tab-separated-values"):
-        if key.lower().endswith(".csv"):
-            obj["ContentType"] = "text/csv"
-        if key.lower().endswith(".tsv"):
-            obj["ContentType"] = "text/tab-separated-values"
-
-
 def get_file_report(s3, bucket, key):
     report = {
         "csv_valid": False,
@@ -46,11 +38,10 @@ def get_file_report(s3, bucket, key):
     }
 
     obj = s3.get_object(Bucket=bucket, Key=key)
-    fix_mime_type(key, obj)
     report = {**report, **get_object_report(obj)}
 
     if not report["errors"]:
-        report = {**report, **get_csv_report(obj)}
+        report = {**report, **get_csv_report(obj, key)}
 
     return report
 


### PR DESCRIPTION
In most cases we can't rely on the mimetype being good and we're guessing it from the extension.
Given that, guessing the mimetype from the extension and then using/validating the mimetype is just a pointless layer of indirection for using the extension directly.