### PR TITLE
Remove any #issuecomment- fragment from github_issue

### DIFF
--- a/trigger/handler.py
+++ b/trigger/handler.py
@@ -177,7 +177,8 @@ def main(event, context):
         issue = raise_github_issue(
             CONSTANTS["GITHUB_API_KEY"], CONSTANTS["GITHUB_REPO"], report
         )
-        report["github_issue"] = issue
+        # Remove any "#issuecomment-[...]" fragment
+        report["github_issue"] = issue.split('#')[0]
 
         sync_report_to_s3(s3, CONSTANTS["FINAL_BUCKET_NAME"], prefix, report)
         print("success")


### PR DESCRIPTION
This value is used in WDIV to link to the issue. Where there's an existing issue we don't want the html_url for the comment, just the issue.